### PR TITLE
Replaced dls-controls with DiamondLightSource

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,11 +6,11 @@ A script used from DAWN to calibrate and test Excalibur-RX detectors.
 
     |Build Status|  |Coverage Status|  |Code Health|  |Docs|
 
-.. |Build Status| image:: https://api.travis-ci.org/dls-controls/ExcaliburCalibration-DAWN.svg
-    :target: https://travis-ci.org/dls-controls/ExcaliburCalibration-DAWN
-.. |Coverage Status| image:: https://coveralls.io/repos/github/dls-controls/ExcaliburCalibration-DAWN/badge.svg?branch=master
-    :target: https://coveralls.io/github/dls-controls/ExcaliburCalibration-DAWN?branch=master
-.. |Code Health| image:: https://landscape.io/github/dls-controls/ExcaliburCalibration-DAWN/master/landscape.svg?style=flat
-    :target: https://landscape.io/github/dls-controls/ExcaliburCalibration-DAWN/master
+.. |Build Status| image:: https://api.travis-ci.org/DiamondLightSource/ExcaliburCalibration-DAWN.svg
+    :target: https://travis-ci.org/DiamondLightSource/ExcaliburCalibration-DAWN
+.. |Coverage Status| image:: https://coveralls.io/repos/github/DiamondLightSource/ExcaliburCalibration-DAWN/badge.svg?branch=master
+    :target: https://coveralls.io/github/DiamondLightSource/ExcaliburCalibration-DAWN?branch=master
+.. |Code Health| image:: https://landscape.io/github/DiamondLightSource/ExcaliburCalibration-DAWN/master/landscape.svg?style=flat
+    :target: https://landscape.io/github/DiamondLightSource/ExcaliburCalibration-DAWN/master
 .. |Docs| image:: https://readthedocs.org/projects/excaliburcalibration-dawn/badge/?version=latest
     :target: http://excaliburcalibration-dawn.readthedocs.io/en/latest/

--- a/docs/developer.rst
+++ b/docs/developer.rst
@@ -37,7 +37,7 @@ The excaliburTestApp CLI tool used in this module is a C program (using various 
 Contributing
 ------------
 
-This python package is hosted on GitHub at `ExcaliburCalibration-DAWN <https://github.com/dls-controls/ExcaliburCalibration-DAWN>`_ under continuous integration controls (`Travis <https://en.wikipedia.org/wiki/Travis_CI>`_, `Coverage <https://coverage.readthedocs.io/en/coverage-4.2/>`_ and `Landscape <https://docs.landscape.io/faq.html>`_).
+This python package is hosted on GitHub at `ExcaliburCalibration-DAWN <https://github.com/DiamondLightSource/ExcaliburCalibration-DAWN>`_ under continuous integration controls (`Travis <https://en.wikipedia.org/wiki/Travis_CI>`_, `Coverage <https://coverage.readthedocs.io/en/coverage-4.2/>`_ and `Landscape <https://docs.landscape.io/faq.html>`_).
 
 Changes should be made on a branch, tested, and then merged into master via a pull request.
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -3,7 +3,7 @@ Repo
 
 To checkout the module from GitHub run the following command in the directory you wish to set up the repo::
 
-    $ git clone git@github.com:dls-controls/ExcaliburCalibration-DAWN.git
+    $ git clone git@github.com:DiamondLightSource/ExcaliburCalibration-DAWN.git
 
 DAWN
 ~~~~


### PR DESCRIPTION
Repository was automatically transferred from `dls-controls/ExcaliburCalibration-DAWN` using https://gitlab.diamond.ac.uk/github/github-scripts